### PR TITLE
Elisp reference to number? fn should use "np" abbrev.

### DIFF
--- a/sotclojure.el
+++ b/sotclojure.el
@@ -72,7 +72,7 @@
 ;;   electric-pair-mode), if you write:
 ;;
 ;;   ┌────
-;;   │ (wl SPC {ck SPC x C-f C-RET (a SPC (sp SPC y C-f SPC f SPC y
+;;   │ (wl SPC {ck SPC x C-f C-RET (a SPC (np SPC y C-f SPC f SPC y
 ;;   └────
 ;;
 ;;   You get


### PR DESCRIPTION
Should look familiar: https://github.com/Malabarba/speed-of-thought-clojure/commit/be841f2d1603312ecd5492e8da2da4a8c611222e :)
